### PR TITLE
fix: BitmapDrawable cannot be cast to VectorDrawable

### DIFF
--- a/android/src/main/java/com/klarna/vectordrawable/VectorDrawableManager.java
+++ b/android/src/main/java/com/klarna/vectordrawable/VectorDrawableManager.java
@@ -92,11 +92,6 @@ public class VectorDrawableManager extends SimpleViewManager<ImageView> {
         }
 
         Drawable drawable = ContextCompat.getDrawable(context, resourceIdent);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            return (VectorDrawable) drawable;
-        } else {
-            return (BitmapDrawable) drawable;
-        }
+        return drawable;
     }
 }


### PR DESCRIPTION
Hello! 👋 

So, I do not have a way to reproduce the crash locally, but in my crash reporting I see the following logged:

```
ClassCastException
android.graphics.drawable.BitmapDrawable cannot be cast to android.graphics.drawable.VectorDrawable
```

it happened on Nexus 5X, android 6.0.1

<img width="821" alt="Screen Shot 2022-04-04 at 19 07 00" src="https://user-images.githubusercontent.com/1566403/161540278-0cde9fef-b208-4f92-9346-a5d6be9fab6f.png">

I'm not sure why exactly the cast is there, as the method returns simply `Drawable`, so the change should make no difference in behavior.

Tested locally on emulator.

Thanks! :)


